### PR TITLE
Add executable flag and python3 shebang

### DIFF
--- a/cum.py
+++ b/cum.py
@@ -1,3 +1,4 @@
+#!/usr/bin/env python3
 from scrapers import series_by_url
 import click
 import db


### PR DESCRIPTION
This actually allows people to just type `./cum.py` in the current working dir to make use of their cum.