### PR TITLE
BeautifulSoup4 warning fix

### DIFF
--- a/config.py
+++ b/config.py
@@ -31,8 +31,8 @@ class BaseConfig(object):
         self.html_parser = j.get('html_parser', 'html.parser')
 
     def write(self):
-        config = self.__dict__
-        config['madokami'] = self.madokami.__dict__
+        config = dict(self.__dict__)
+        config['madokami'] = dict(self.madokami.__dict__)
 
         with open(config_path, 'w') as file:
             json.dump(config, file, indent=2)

--- a/config.py
+++ b/config.py
@@ -28,6 +28,7 @@ class BaseConfig(object):
         self.cbz = j.get('cbz', False)
         self.download_directory = j.get('download_directory', home_dir)
         self.madokami = MadokamiConfig(j.get('madokami', {}))
+        self.html_parser = j.get('html_parser', 'html.parser')
 
     def write(self):
         config = self.__dict__

--- a/config.py
+++ b/config.py
@@ -30,14 +30,8 @@ class BaseConfig(object):
         self.madokami = MadokamiConfig(j.get('madokami', {}))
 
     def write(self):
-        config = {
-            'cbz': self.cbz,
-            'download_directory': self.download_directory,
-            'madokami': {
-                'username': self.madokami.username,
-                'password': self.madokami.password
-            }
-        }
+        config = self.__dict__
+        config['madokami'] = self.madokami.__dict__
 
         with open(config_path, 'w') as file:
             json.dump(config, file, indent=2)

--- a/scrapers/batoto.py
+++ b/scrapers/batoto.py
@@ -2,6 +2,7 @@ from bs4 import BeautifulSoup
 from mimetypes import guess_extension
 from scrapers.base import BaseChapter, BaseSeries
 from tempfile import NamedTemporaryFile
+from config import config
 import os
 import re
 import requests
@@ -13,7 +14,7 @@ class BatotoSeries(BaseSeries):
     def __init__(self, url):
         r = requests.get(url)
         self.url = url
-        self.soup = BeautifulSoup(r.text)
+        self.soup = BeautifulSoup(r.text, config.html_parser)
         self.chapters = self.get_chapters()
 
     @property
@@ -56,14 +57,14 @@ class BatotoChapter(BaseChapter):
 
     def download(self):
         r = requests.get(self.url)
-        soup = BeautifulSoup(r.text)
+        soup = BeautifulSoup(r.text, config.html_parser)
         pages = [x.get('value') for x in soup.find('select', id='page_select')
                                              .find_all('option')]
         files = []
         with self.progress_bar(pages) as bar:
             for page in bar:
                 r = requests.get(page)
-                soup = BeautifulSoup(r.text)
+                soup = BeautifulSoup(r.text, config.html_parser)
                 image = soup.find('img', id='comic_page').get('src')
                 r = requests.get(image, stream=True)
                 ext = guess_extension(r.headers.get('content-type'))

--- a/scrapers/dynastyscans.py
+++ b/scrapers/dynastyscans.py
@@ -3,6 +3,7 @@ from mimetypes import guess_extension
 from scrapers.base import BaseChapter, BaseSeries
 from tempfile import NamedTemporaryFile
 from urllib.parse import urljoin
+from config import config
 import re
 import requests
 
@@ -14,7 +15,7 @@ class DynastyScansSeries(BaseSeries):
     def __init__(self, url):
         r = requests.get(url)
         self.url = url
-        self.soup = BeautifulSoup(r.text)
+        self.soup = BeautifulSoup(r.text, config.html_parser)
         self.chapters = self.get_chapters()
 
     @property
@@ -72,12 +73,12 @@ class DynastyScansChapter(BaseChapter):
 
     def get_groups(self):
         r = requests.get(self.url)
-        soup = BeautifulSoup(r.text)
+        soup = BeautifulSoup(r.text, config.html_parser)
         links = soup.find('span', class_='scanlators').find_all('a')
         groups = []
         for link in links:
             r = requests.get(urljoin(self.url, link.get('href')))
-            s = BeautifulSoup(r.text)
+            s = BeautifulSoup(r.text, config.html_parser)
             g = s.find('h2', class_='tag-title').b.string
             groups.append(g)
         return groups

--- a/scrapers/madokami.py
+++ b/scrapers/madokami.py
@@ -15,7 +15,7 @@ class MadokamiSeries(BaseSeries):
     def __init__(self, url):
         r = requests.get(url)
         self.url = url
-        self.soup = BeautifulSoup(r.text)
+        self.soup = BeautifulSoup(r.text, config.html_parser)
         self.chapters = self.get_chapters()
 
     @property


### PR DESCRIPTION
Earlier, each time BeautifulSoup was initialised, it would generate the following warning:

```
/usr/lib/python3.4/site-packages/bs4/__init__.py:166: UserWarning: No parser was explicitly specified, so I'm using the best available HTML parser for this system ("html.parser"). This usually isn't a problem, but if you run this code on another system, or in a different virtual environment, it may use a different parser and behave differently.

To get rid of this warning, change this:

 BeautifulSoup([your markup])

to this:

 BeautifulSoup([your markup], "html.parser")
```

By making the parser configurable in the config.json and passing it explicitly, we get rid of this. Furthermore, 'html.parser' is now the default, as it comes with python and on recent-ish python installations is totally fine to use.

Furthermore, the config serialisation was made less redundant. Unfortunately __dict__ isn't recursive though, which is why this isn't quite a one-liner.