### PR TITLE
Construct path/DB URL using helper functions, avoid importing db and others if not needed

### DIFF
--- a/cum/cum.py
+++ b/cum/cum.py
@@ -1,12 +1,11 @@
 #!/usr/bin/env python3
-from cum import db, output
-from cum.scrapers import series_by_url
 import click
-
 
 @click.group()
 def cli():
-    pass
+    global db, output, series_by_url
+    from cum import db, output
+    from cum.scrapers import series_by_url
 
 
 @cli.command()

--- a/cum/db.py
+++ b/cum/db.py
@@ -13,6 +13,7 @@ from sqlalchemy import (
 from sqlalchemy.ext.declarative import declarative_base
 from sqlalchemy.orm import relationship, sessionmaker
 from sqlalchemy.orm.exc import NoResultFound
+import sqlalchemy.engine.url
 from urllib.parse import urlparse
 import click
 import os
@@ -172,8 +173,10 @@ class Group(Base):
     def __str__(self):
         return self.name
 
-db_path = cum_dir + '/cum.db'
-engine = create_engine('sqlite:///' + db_path)
+
+db_path = os.path.join(cum_dir, 'cum.db')
+db_url = sqlalchemy.engine.url.URL('sqlite', database=db_path)
+engine = create_engine(db_url)
 if not os.path.exists(db_path):
     Base.metadata.create_all(bind=engine)
 Session = sessionmaker(bind=engine)


### PR DESCRIPTION
I noticed a case where cum was building paths by concatenating strings, which is generally not a good idea due to platform differences and might break if somebody changes cum_dir in the future depending on whether they add a slash at the end or not.

While I was at it, I noticed that cum took quite a long time to get going, which can be frustrating for the more impatient users. When we're auto-completing commands or simply asking for help, we don't need everything cum has to offer, so we don't need to work the entirety of the python to get the desired cum output.

Thinking the slowdown was caused by the application establishing a database connection even if none is needed, I first tried to have the db session be created lazily. While that worked it didn't give the desired speed-up, and later profiling revealed that the bulk of the time was just python importing stuff since db pulls in quite a lot. So I scrapped said code and instead just made the cli command group do the imports.

On my system, this reduced the time cum needs to get going from 440msec to about 120msec for the cases where we don't actually call any of the commands.