### PR TITLE
Implement parallel downloading

### DIFF
--- a/cum/config.py
+++ b/cum/config.py
@@ -29,6 +29,7 @@ class BaseConfig(object):
         self.cbz = j.get('cbz', False)
         self.compact_new = j.get('compact_new', False)
         self.download_directory = j.get('download_directory', home_dir)
+        self.download_threads = j.get('download_threads', 4)
         self.html_parser = j.get('html_parser', 'html.parser')
         self.madokami = MadokamiConfig(self, j.get('madokami', {}))
 


### PR DESCRIPTION
Add parallel downloads for bato.to and DynastyScans. The default number of threads that are used for parallel downloads is 4.

Futures are used to implement this functionality, and the files are assigned to the list of files in the correct position as the futures complete, allowing the progress bar to be updated in a quicker fashion than it would be possible if the futures were iterated in the order they were submitted, as downloads may not complete sequentially.

For bato.to, image URLs are predicted based on the previous URL. If that prediction fails in some way, resort to scraping the page again.

As some bato.to series apparently use a different image URL scheme, a second regular expression is needed for those cases; both cases are tried, falling back to scraping the page should neither work.

Future work in this area may include the following:
* Making the update process parallel
* ~~Somehow checking for completed futures while downloads are being queued, to reduce the initial "lag" the progress bar has as downloads complete before the code has finished submitting download tasks.~~ *Fixed now!*