### PR TITLE
Explicitly close streaming requests

### DIFF
--- a/cum/scrapers/base.py
+++ b/cum/scrapers/base.py
@@ -242,6 +242,7 @@ class BaseChapter(metaclass=ABCMeta):
             if chunk:
                 f.write(chunk)
         f.flush()
+        r.close()
         return((page_num, f))
 
     @staticmethod

--- a/cum/scrapers/batoto.py
+++ b/cum/scrapers/batoto.py
@@ -152,6 +152,7 @@ class BatotoChapter(BaseChapter):
                         image = "".join(mg)
                     r = requests.get(image, stream=True)
                     if r.status_code == 404:
+                        r.close()
                         raise ValueError
                 except ValueError:  # If we fail to do prediction, scrape
                     r = self.reader_get(i + 1)


### PR DESCRIPTION
According to the [Requests documentation in the "Body Content Workflow" heading](http://docs.python-requests.org/en/master/user/advanced/#body-content-workflow), the Request objects of streaming requests may not be released back into the request pool if the content is not fully consumed and the request is not explicitly closed.

While the page downloads do consume all of their data, we can close those requests explicitly as soon as we finish just to be sure. One area where a streaming request may have gone unclosed was if batoto failed to predict an image url - the request body would go unread.