### PR TITLE
More robust login error handling

### DIFF
--- a/README.md
+++ b/README.md
@@ -92,18 +92,7 @@ $ cum download school-live
 
 ## Supported sites
 
-* Batoto
-  * Slow downloads
-  * Account required
-  * Reliable due to relatively standard naming format
-* Dynasty Reader
-  * Moderate speed downloads
-  * Account not required
-  * Reliable downloads
-* Madokami
-  * Fast downloads
-  * Account required
-  * Non-fixed format names for files combined with imperfect regex causes naming issues/exceptions
+See the [Supported sites](../../wiki/Supported-sites) wiki page for details.
 
 ## Dependencies
 

--- a/cum/config.py
+++ b/cum/config.py
@@ -75,7 +75,7 @@ class BatotoConfig(object):
             self.member_id = r.cookies['member_id']
             self.pass_hash = r.cookies['pass_hash']
         except KeyError:
-            raise exceptions.LoginError('Invalid Batoto login')
+            raise exceptions.LoginError('Batoto login error')
         self._config.write()
 
     @property

--- a/cum/config.py
+++ b/cum/config.py
@@ -1,4 +1,4 @@
-from cum import output
+from cum import exceptions, output
 import click
 import json
 import os
@@ -75,8 +75,7 @@ class BatotoConfig(object):
             self.member_id = r.cookies['member_id']
             self.pass_hash = r.cookies['pass_hash']
         except KeyError:
-            output.error('Batoto: invalid login')
-            exit(1)
+            raise exceptions.LoginError('Invalid Bato.to login')
         self._config.write()
 
     @property

--- a/cum/config.py
+++ b/cum/config.py
@@ -75,7 +75,7 @@ class BatotoConfig(object):
             self.member_id = r.cookies['member_id']
             self.pass_hash = r.cookies['pass_hash']
         except KeyError:
-            raise exceptions.LoginError('Invalid Bato.to login')
+            raise exceptions.LoginError('Invalid Batoto login')
         self._config.write()
 
     @property

--- a/cum/cum.py
+++ b/cum/cum.py
@@ -152,7 +152,7 @@ def follow(urls, directory, download, ignore):
                 chapter.get()
             except exceptions.LoginError as e:
                 output.warning('Could not download {}: {}'
-                               .format(chapter.name, e.message))
+                               .format(chapter.alias, e.message))
                 continue
 
 

--- a/cum/cum.py
+++ b/cum/cum.py
@@ -109,8 +109,8 @@ def download(aliases):
         try:
             chapter.get()
         except exceptions.LoginError as e:
-            output.warning('Could not download {}: {}'
-                            .format(chapter.name, e.message))
+            output.warning('Could not download {c.alias} {c.chapter}: {e}'
+                           .format(c=chapter, e=e.message))
             continue
 
 
@@ -132,7 +132,7 @@ def follow(urls, directory, download, ignore):
             output.warning('Scraping error ({})'.format(url))
             continue
         except exceptions.LoginError as e:
-            output.warning('Login error ({}): {}'.format(url, e.message))
+            output.warning('{} ({})'.format(e.message, url))
             continue
         if not series:
             output.warning('Invalid URL "{}"'.format(url))
@@ -151,8 +151,8 @@ def follow(urls, directory, download, ignore):
             try:
                 chapter.get()
             except exceptions.LoginError as e:
-                output.warning('Could not download {}: {}'
-                               .format(chapter.alias, e.message))
+                output.warning('Could not download {c.alias} {c.chapter}: {e}'
+                               .format(c=chapter, e=e.message))
                 continue
 
 
@@ -192,7 +192,7 @@ def get(input, directory):
             output.warning('Scraping error ({})'.format(i))
             continue
         except exceptions.LoginError as e:
-            output.warning('Login error ({}): {}'.format(i, e.message))
+            output.warning('{} ({})'.format(e.message, i))
             continue
         if series:
             chapter_list += series.chapters
@@ -202,7 +202,7 @@ def get(input, directory):
             output.warning('Scraping error ({})'.format(i))
             continue
         except exceptions.LoginError as e:
-            output.warning('Login error ({}): {}'.format(i, e.message))
+            output.warning('{} ({})'.format(e.message, i))
             continue
         if chapter:
             chapter_list.append(chapter)
@@ -224,8 +224,8 @@ def get(input, directory):
         try:
             chapter.get(use_db=False)
         except exceptions.LoginError as e:
-            output.warning('Could not download {}: {}'
-                            .format(chapter.name, e.message))
+            output.warning('Could not download {c.alias} {c.chapter}: {e}'
+                           .format(c=chapter, e=e.message))
             continue
 
 
@@ -365,7 +365,7 @@ def update():
                                 .format(aliases[future]))
             except exceptions.LoginError as e:
                 warnings.append('Unable to update {} ({})'
-                                .format(aliases[future], e.message.lower()))
+                                .format(aliases[future], e.message))
             else:
                 series.update()
             bar.update(1)

--- a/cum/cum.py
+++ b/cum/cum.py
@@ -357,7 +357,7 @@ def update():
         for future in concurrent.futures.as_completed(futures):
             try:
                 series = future.result()
-            except requests.exceptions.ConnectionError as e:
+            except exceptions.ConnectionError:
                 warnings.append('Unable to update {} (connection error)'
                                 .format(aliases[future]))
             except exceptions.ScrapingError:
@@ -365,7 +365,7 @@ def update():
                                 .format(aliases[future]))
             except exceptions.LoginError as e:
                 warnings.append('Unable to update {} ({})'
-                                .format(aliases[future], e.message))
+                                .format(aliases[future], e.message.lower()))
             else:
                 series.update()
             bar.update(1)

--- a/cum/exceptions.py
+++ b/cum/exceptions.py
@@ -13,3 +13,7 @@ class CumException(Exception):
 
 class ScrapingError(CumException):
     pass
+
+
+class LoginError(CumException):
+    pass

--- a/cum/scrapers/batoto.py
+++ b/cum/scrapers/batoto.py
@@ -26,7 +26,7 @@ class BatotoSeries(BaseSeries):
 
     def get_chapters(self):
         if self.soup.find('div', id='register_notice'):
-            raise exceptions.LoginError('Invalid Bato.to login')
+            raise exceptions.LoginError('Invalid Batoto login')
         rows = self.soup.find_all('tr', class_="row lang_English chapter_row")
         chapters = []
         for row in rows:

--- a/cum/scrapers/batoto.py
+++ b/cum/scrapers/batoto.py
@@ -26,7 +26,7 @@ class BatotoSeries(BaseSeries):
 
     def get_chapters(self):
         if self.soup.find('div', id='register_notice'):
-            raise exceptions.LoginError('Invalid Batoto login')
+            raise exceptions.LoginError('Batoto login error')
         rows = self.soup.find_all('tr', class_="row lang_English chapter_row")
         chapters = []
         for row in rows:

--- a/cum/scrapers/batoto.py
+++ b/cum/scrapers/batoto.py
@@ -25,6 +25,8 @@ class BatotoSeries(BaseSeries):
         return self.soup.find('h1').string.strip()
 
     def get_chapters(self):
+        if self.soup.find('div', id='register_notice'):
+            raise exceptions.LoginError('Invalid Bato.to login')
         rows = self.soup.find_all('tr', class_="row lang_English chapter_row")
         chapters = []
         for row in rows:

--- a/cum/scrapers/madokami.py
+++ b/cum/scrapers/madokami.py
@@ -88,7 +88,7 @@ class MadokamiChapter(BaseChapter):
         auth = requests.auth.HTTPBasicAuth(*config.get().madokami.login)
         with closing(requests.get(self.url, auth=auth, stream=True)) as r:
             if r.status_code == 401:
-                raise exceptions.LoginError('Invalid Madokami login')
+                raise exceptions.LoginError('Madokami login error')
             total_length = r.headers.get('content-length')
             with open(self.filename, 'wb') as f:
                 if total_length is None:

--- a/tests/test_batoto.py
+++ b/tests/test_batoto.py
@@ -153,6 +153,23 @@ class TestBatoto(unittest.TestCase):
         chapter = batoto.BatotoChapter(url=URL)
         assert chapter.available() is False
 
+    def test_series_invalid_login(self):
+        URL = 'https://bato.to/comic/_/comics/stretch-r11259'
+        config.get().batoto.password = '12345'
+        config.get().batoto.username = 'KoalaBeer'
+        with self.assertRaises(exceptions.LoginError):
+            series = batoto.BatotoSeries(url=URL)
+
+    def test_series_invalid_login_2(self):
+        URL = 'https://bato.to/comic/_/comics/stretch-r11259'
+        config.get().batoto.password = '12345'
+        config.get().batoto.username = 'KoalaBeer'
+        config.get().batoto.member_id = 'Invalid'
+        config.get().batoto.pass_hash = 'Invalid'
+        config.get().batoto.cookie = 'Invalid'
+        with self.assertRaises(exceptions.LoginError):
+            series = batoto.BatotoSeries(url=URL)
+
     def test_series_molester_man(self):
         data = {'alias': 'molester-man',
                 'chapters': ['1', '2', '3', '4', '5', '6', '7', '8', '9', '10',

--- a/tests/test_cli.py
+++ b/tests/test_cli.py
@@ -307,7 +307,7 @@ class TestCLI(unittest.TestCase):
         URL = 'http://bato.to/reader#f0fbe77dbcc60780'
         MESSAGES = ['Batoto username:',
                     'Batoto password:',
-                    'Invalid Bato.to login']
+                    'Invalid Batoto login']
 
         config.get().batoto.username = None
         config.get().batoto.password = None

--- a/tests/test_cli.py
+++ b/tests/test_cli.py
@@ -126,6 +126,22 @@ class TestCLI(unittest.TestCase):
         assert os.path.isfile(os.path.join(self.directory.name,
                                            FILENAME)) is True
 
+    def test_download_invalid_login(self):
+        URL = ('https://manga.madokami.com/Manga/Oneshots/100%20Dollar%20wa%20'
+               'Yasu%20Sugiru')
+        MESSAGE = ('Could not download 100-dollar-wa-yasu-sugiru 000 '
+                   '[Oneshot]: Madokami login error')
+
+        series = scrapers.MadokamiSeries(URL)
+        series.follow()
+        config.get().madokami.password = '12345'
+        config.get().madokami.username = 'KoalaBeer'
+        config.get().write()
+
+        result = self.invoke('download')
+        assert result.exit_code == 0
+        assert MESSAGE in result.output
+
     def test_download_removed(self):
         URL = 'http://bato.to/comic/_/comics/tomo-chan-wa-onna-no-ko-r15722'
         CHAPTER_URL = 'http://bato.to/reader#ba173e587bdc9325'
@@ -200,6 +216,18 @@ class TestCLI(unittest.TestCase):
         for chapter in chapters:
             assert chapter.downloaded == -1
 
+    def test_follow_batoto_invalid_login(self):
+        URL = 'http://bato.to/comic/_/comics/hot-road-r2243'
+        MESSAGE = 'Batoto login error ({})'.format(URL)
+
+        config.get().batoto.password = 'Notvalid'
+        config.get().batoto.username = 'Notvalid'
+        config.get().write()
+
+        result = self.invoke('follow', URL)
+        assert result.exit_code == 0
+        assert MESSAGE in result.output
+
     def test_follow_batoto_refollow_with_directory(self):
         URL = 'http://bato.to/comic/_/comics/dog-days-r6928'
         DIRECTORY1 = 'olddirectory'
@@ -243,6 +271,19 @@ class TestCLI(unittest.TestCase):
         MESSAGE = 'Adding follow for Akuma no Riddle (akuma-no-riddle)'
 
         result = self.invoke('follow', URL)
+        assert result.exit_code == 0
+        assert MESSAGE in result.output
+
+    def test_follow_madokami_download_invalid_login(self):
+        URL = 'https://manga.madokami.com/Manga/A/AK/AKUM/Akuma%20no%20Riddle'
+        MESSAGE = ('Could not download akuma-no-riddle 00-08: '
+                   'Madokami login error')
+
+        config.get().madokami.password = 'notworking'
+        config.get().madokami.username = 'notworking'
+        config.get().write()
+
+        result = self.invoke('follow', URL, '--download')
         assert result.exit_code == 0
         assert MESSAGE in result.output
 
@@ -307,7 +348,7 @@ class TestCLI(unittest.TestCase):
         URL = 'http://bato.to/reader#f0fbe77dbcc60780'
         MESSAGES = ['Batoto username:',
                     'Batoto password:',
-                    'Invalid Batoto login']
+                    'Batoto login error ({})'.format(URL)]
 
         config.get().batoto.username = None
         config.get().batoto.password = None
@@ -324,7 +365,7 @@ class TestCLI(unittest.TestCase):
                '.zip')
         MESSAGES = ['Madokami username:',
                     'Madokami password:',
-                    'Invalid Madokami login']
+                    'Madokami login error']
 
         config.get().madokami.username = None
         config.get().madokami.password = None
@@ -351,6 +392,18 @@ class TestCLI(unittest.TestCase):
             assert message in result.output
         for file in files:
             assert os.path.isfile(file) is True
+
+    def test_get_series_batoto_invalid_login(self):
+        URL = 'http://bato.to/comic/_/comics/gekkou-spice-r2863'
+        MESSAGE = 'Batoto login error ({})'.format(URL)
+
+        config.get().batoto.password = 'Password1'
+        config.get().batoto.username = 'Username1'
+        config.get().write()
+
+        result = self.invoke('get', URL)
+        assert result.exit_code == 0
+        assert MESSAGE in result.output
 
     def test_ignore(self):
         URL = 'http://bato.to/comic/_/eien-no-mae-r8817'
@@ -517,6 +570,23 @@ class TestCLI(unittest.TestCase):
         for message in MESSAGES:
             assert message in result.output
         assert len(chapters) == 16
+
+    def test_update_invalid_login(self):
+        URL = 'http://bato.to/comic/_/comics/femme-fatale-r468'
+        MESSAGE = 'Unable to update femme-fatale (Batoto login error)'
+
+        series = scrapers.BatotoSeries(URL)
+        series.follow()
+        config.get().batoto.cookie = None
+        config.get().batoto.member_id = None
+        config.get().batoto.pass_hash = None
+        config.get().batoto.password = 'Notvalid'
+        config.get().batoto.username = 'Notvalid'
+        config.get().write()
+
+        result = self.invoke('update')
+        assert result.exit_code == 0
+        assert MESSAGE in result.output
 
 if __name__ == '__main__':
     unittest.main()

--- a/tests/test_cli.py
+++ b/tests/test_cli.py
@@ -307,14 +307,13 @@ class TestCLI(unittest.TestCase):
         URL = 'http://bato.to/reader#f0fbe77dbcc60780'
         MESSAGES = ['Batoto username:',
                     'Batoto password:',
-                    'Batoto: invalid login']
+                    'Invalid Bato.to login']
 
         config.get().batoto.username = None
         config.get().batoto.password = None
         config.get().write()
 
         result = self.invoke('get', URL, input='a\na')
-        assert result.exit_code == 1
         for message in MESSAGES:
             assert message in result.output
 
@@ -325,14 +324,13 @@ class TestCLI(unittest.TestCase):
                '.zip')
         MESSAGES = ['Madokami username:',
                     'Madokami password:',
-                    'Madokami: invalid login']
+                    'Invalid Madokami login']
 
         config.get().madokami.username = None
         config.get().madokami.password = None
         config.get().write()
 
         result = self.invoke('get', URL, input='a\na')
-        assert result.exit_code == 1
         for message in MESSAGES:
             assert message in result.output
 

--- a/tests/test_madokami.py
+++ b/tests/test_madokami.py
@@ -1,4 +1,4 @@
-from cum import config
+from cum import config, exceptions
 import os
 import tempfile
 import unittest
@@ -47,6 +47,12 @@ class TestMadokami(unittest.TestCase):
             '7-Daime no Tomari - c001 [Unknown].zip'
         )
         assert chapter.filename == path
+
+    def test_chapter_invalid_login(self):
+        config.get().madokami.password = '12345'
+        config.get().madokami.username = 'Koala'
+        with self.assertRaises(exceptions.LoginError):
+            self.test_chapter_100_dollar_too_cheap()
 
     def test_chapter_100_dollar_too_cheap(self):
         URL = ('https://manga.madokami.com/Manga/Oneshots/100%20Dollar%20wa%20'


### PR DESCRIPTION
Throws exceptions on login errors and detects Madokami login error based on the status code. Similar to scraping errors, login errors are not fatal. They simply produce a warning and move on.

I also fixed a bug I introduced while rebasing a previous PR in cum.py's `update`, the `ScrapingError` except condition should've used `aliases[future]`.