### PR TITLE
Do not write default config values back to config file

### DIFF
--- a/README.md
+++ b/README.md
@@ -20,7 +20,7 @@ To print out a list of available commands, use `cum --help`. For help with a par
 
 ### Config
 
-Config is stored at `~/.cum/config.json` and is automatically created with default values when the program is ran for the first time.
+Config is stored at `~/.cum/config.json` and overwrites the following default values. Cum will not write login information supplied by the user at run-time back to the config file, but will store session cookies if any exist.
 
 ```javascript
 {
@@ -33,7 +33,7 @@ Config is stored at `~/.cum/config.json` and is automatically created with defau
   }
   "cbz": false,  // If true, the archive extension will be .cbz instead of .zip.
   "compact_new": true,  // Uses compact listing mode for `cum new`.
-  "download_directory": "/path/to/manga",  // Directory where manga is downloaded.
+  "download_directory": "~",  // Directory where manga is downloaded.
   "download_threads": 4,  // Maximum number of concurrent downloads.
   "html_parser": "html.parser",  // HTML parser used by cum.
   "madokami": {

--- a/README.md
+++ b/README.md
@@ -18,36 +18,18 @@ Users of Arch Linux can install stable versions [from the AUR](https://aur.archl
 
 To print out a list of available commands, use `cum --help`. For help with a particular command, use `cum COMMAND --help`.
 
-### Config
+### Configuration
 
-Config is stored at `~/.cum/config.json` and overwrites the following default values. Cum will not write login information supplied by the user at run-time back to the config file, but will store session cookies if any exist.
+Configuration is stored at `~/.cum/config.json` and overwrites the following default values. cum will not write login information supplied by the user at run-time back to the config file, but will store session cookies if any exist. Configuration can get read with the command `cum config get [SETTING]` and set using `cum config set [SETTING] [VALUE]`.
 
-```javascript
-{
-  "batoto": {
-    "cookie": "",  // Used to login to Batoto.
-    "member_id": "",  // Used to login to Batoto.
-    "pass_hash": "",  // Used to login to Batoto.
-    "password": "",  // Password to use with Batoto logins.
-    "username": ""  // Username to use with Batoto logins.
-  }
-  "cbz": false,  // If true, the archive extension will be .cbz instead of .zip.
-  "compact_new": true,  // Uses compact listing mode for `cum new`.
-  "download_directory": "~",  // Directory where manga is downloaded.
-  "download_threads": 4,  // Maximum number of concurrent downloads.
-  "html_parser": "html.parser",  // HTML parser used by cum.
-  "madokami": {
-    "password": "" // Password to use with Madokami
-    "username": "", // Username to use with Madokami.
-  }
-}
-```
+See the [Configuration](../../wiki/Configuration) wiki page for more details and available settings.
 
 ### Commands
 
 ```
 alias      Assign a new alias to series.
 chapters   List all chapters for a manga series.
+config     Get or set configuration options.
 download   Download all available chapters.
 follow     Follow a series.
   --directory TEXT  Directory which download the series chapters into.

--- a/cum/config.py
+++ b/cum/config.py
@@ -10,6 +10,14 @@ class BaseConfig(object):
     def __init__(self):
         self.load()
 
+    def __setattr__(self, name, value):
+        """Ensures that changes made after loading with default values
+        are written back to disk.
+        """
+        if hasattr(self, 'persistent_config'):
+            self.persistent_config[name] = value
+        object.__setattr__(self, name, value)
+
     def load(self):
         try:
             f = open(config_path)
@@ -30,24 +38,21 @@ class BaseConfig(object):
 
         self.persistent_config = j
 
-    def __setattr__(self, name, value):
-        """Ensures that changes made after loading with default values
-        are written back to disk.
-        """
-        if hasattr(self, 'persistent_config'):
-            self.persistent_config[name] = value
-        object.__setattr__(self, name, value)
+    def serialize(self):
+        """Returns the current persistent configuration as a dictionary."""
+        configuration = dict(self.persistent_config)
+        configuration['batoto'] = dict(self.batoto.__dict__)
+        configuration['madokami'] = dict(self.madokami.__dict__)
+        del configuration['batoto']['_config']
+        del configuration['madokami']['_config']
+        return configuration
 
     def write(self):
         if hasattr(self, 'persistent_config'):
-            config = dict(self.persistent_config)
-            config['batoto'] = dict(self.batoto.__dict__)
-            config['madokami'] = dict(self.madokami.__dict__)
-            del config['batoto']['_config']
-            del config['madokami']['_config']
+            configuration = self.serialize()
 
             with open(config_path, 'w') as file:
-                json.dump(config, file, sort_keys=True, indent=2)
+                json.dump(configuration, file, sort_keys=True, indent=2)
 
 
 class BatotoConfig(object):

--- a/cum/output.py
+++ b/cum/output.py
@@ -8,6 +8,27 @@ def chapter(msg):
     )
 
 
+def configuration(dictionary):
+    settings = configuration_flatten(dictionary)
+    for setting, value in sorted(settings.items()):
+        if value is not None:
+            click.echo('{} = {}'.format(setting, value))
+
+
+def configuration_flatten(dictionary, parent_key=None):
+    items = []
+    for key, value in dictionary.items():
+        if parent_key:
+            new_key = '{}.{}'.format(parent_key, key)
+        else:
+            new_key = key
+        if isinstance(value, dict):
+            items.extend(configuration_flatten(value, new_key).items())
+        else:
+            items.append((new_key, value))
+    return dict(items)
+
+
 def error(msg):
     click.echo(
         click.style('==> ', fg='red') + msg

--- a/tests/test_cli.py
+++ b/tests/test_cli.py
@@ -88,6 +88,103 @@ class TestCLI(unittest.TestCase):
         assert result.exit_code == 1
         assert MESSAGE in result.output
 
+    def test_config_get(self):
+        MESSAGES = ['batoto.password = ' + config.get().batoto.password,
+                    'batoto.username = ' + config.get().batoto.username,
+                    'download_directory = ' + config.get().download_directory,
+                    'madokami.password = ' + config.get().madokami.password,
+                    'madokami.username = ' + config.get().madokami.username]
+
+        result = self.invoke('config', 'get')
+        assert result.exit_code == 0
+        for message in MESSAGES:
+            assert message in result.output
+
+    def test_config_get_batoto_username(self):
+        MESSAGE = 'batoto.username = ' + config.get().batoto.username
+
+        result = self.invoke('config', 'get', 'batoto.username')
+        assert result.exit_code == 0
+        assert MESSAGE in result.output
+
+    def test_config_get_batoto_invalid_value(self):
+        MESSAGE = 'Setting not found'
+
+        result = self.invoke('config', 'get', 'batoto.wrongkey')
+        assert result.exit_code == 1
+        assert MESSAGE in result.output
+
+    def test_config_get_download_directory(self):
+        MESSAGE = 'download_directory = ' + config.get().download_directory
+
+        result = self.invoke('config', 'get', 'download_directory')
+        assert result.exit_code == 0
+        assert MESSAGE in result.output
+
+    def test_config_get_invalid_value(self):
+        MESSAGE = 'Setting not found'
+
+        result = self.invoke('config', 'get', 'wrongkey')
+        assert result.exit_code == 1
+        assert MESSAGE in result.output
+
+    def test_config_invalid_mode(self):
+        MESSAGE = 'Mode must be either get or set'
+
+        result = self.invoke('config', 'poke')
+        assert result.exit_code == 1
+        assert MESSAGE in result.output
+
+    def test_config_set_batoto_password(self):
+        PASSWORD = 'password4testing'
+
+        config.get().batoto.password = None
+        config.get().write()
+
+        result = self.invoke('config', 'set', 'batoto.password', PASSWORD)
+        assert result.exit_code == 0
+        assert config.get().batoto.password == PASSWORD
+
+    def test_config_set_cbz(self):
+        result = self.invoke('config', 'set', 'cbz', 'True')
+        assert result.exit_code == 0
+        assert config.get().cbz is True
+
+    def test_config_set_invalid_setting(self):
+        MESSAGE = 'Setting not found'
+
+        result = self.invoke('config', 'set', 'cuterobots.sex', 'female')
+        assert result.exit_code == 1
+        assert MESSAGE in result.output
+
+    def test_config_set_invalid_subsetting(self):
+        MESSAGE = 'Setting not found'
+
+        result = self.invoke('config', 'set', 'batoto.trashing', 'True')
+        assert result.exit_code == 1
+        assert MESSAGE in result.output
+
+    def test_config_set_no_setting(self):
+        MESSAGE = 'You must specify a setting'
+
+        result = self.invoke('config', 'set')
+        assert result.exit_code == 1
+        assert MESSAGE in result.output
+
+    def test_config_set_no_value(self):
+        MESSAGE = 'You must specify a value'
+
+        result = self.invoke('config', 'set', 'batoto.username')
+        assert result.exit_code == 1
+        assert MESSAGE in result.output
+
+    def test_config_set_type_mismatch(self):
+        MESSAGE = 'Type mismatch: value should be int'
+
+        result = self.invoke('config', 'set', 'download_threads', 'seven')
+        assert result.exit_code == 1
+        assert MESSAGE in result.output
+
     def test_download(self):
         URLS = ['http://bato.to/comic/_/comics/goodbye-body-r13725',
                 'http://bato.to/comic/_/comics/green-beans-r15344']


### PR DESCRIPTION
By not writing default values back to the config file, we can distinguish between user-set values and default values, which means we can effectively change default values for existing installations at a later date.

Attributes of the configuration which are changed after loading is complete are counted as changes meant to be reflected in the persistent configuration.

Judging by unit tests, a developer might expect that changes directly made to the config file after initial loading are written back to disk. To avoid any subtle breakage or confusion, this behaviour was kept as-is.

For this purpose, a new attribute named `persistent_config` was introduced, and the `BaseConfig.__setattr__` method was defined. If the `persistent_config` attribute exists, any attributes set in the `BaseConfig` object will also be set in the `BaseConfig.persistent_config` dict.

The `write()` call inside `BaseConfig.__init__` was removed, as there are no possible persistent changes directly after a `load()` call.

The README.md text was altered slightly to reflect these changes.