### PR TITLE
Fix Madokami updates and downloads

### DIFF
--- a/tests/test_cli.py
+++ b/tests/test_cli.py
@@ -383,8 +383,7 @@ class TestCLI(unittest.TestCase):
 
     def test_follow_madokami_download_invalid_login(self):
         URL = 'https://manga.madokami.com/Manga/A/AK/AKUM/Akuma%20no%20Riddle'
-        MESSAGE = ('Could not download akuma-no-riddle 00-08: '
-                   'Madokami login error')
+        MESSAGE = '==> Madokami login error (' + URL + ')'
 
         config.get().madokami.password = 'notworking'
         config.get().madokami.username = 'notworking'


### PR DESCRIPTION
Recently, Madokami started requiring logins even to just view what series were present. This broke cum, which until now assumed that only downloads require authentication.

By using sessions, we can fix this for now. The solution isn't ideal, as I'd like to explore the possibility to instantiate per-scraper objects that contain the session for the lifetime of the program in the future, instead of having the series object pass its session down to the chapter objects.