### PR TITLE
Fix 'cum latest' if used with alias parameter

### DIFF
--- a/cum/cum.py
+++ b/cum/cum.py
@@ -303,10 +303,12 @@ def ignore(alias, chapters):
               help='Uses relative times instead of absolute times.')
 def latest(alias, relative):
     """List most recent chapter addition for series."""
-    query = (db.session.query(db.Series)
-                       .filter_by(following=True)
-                       .order_by(db.Series.alias)
-                       .all())
+    query = db.session.query(db.Series)
+    if alias:
+        query = query.filter_by(following=True, alias=alias)
+    else:
+        query = query.filter_by(following=True)
+    query = query.order_by(db.Series.alias).all()
     updates = []
     for series in query:
         if series.last_added is None:

--- a/tests/test_cli.py
+++ b/tests/test_cli.py
@@ -574,6 +574,24 @@ class TestCLI(unittest.TestCase):
         assert result.exit_code == 0
         assert MESSAGE in result.output
 
+    def test_latest_alias(self):
+        URLS = ['http://bato.to/comic/_/comics/cat-gravity-r11269',
+                'http://bato.to/comic/_/comics/cerberus-r1588']
+        MESSAGE = 'cat-gravity   2013-12-11 10:09\n'
+
+        for url in URLS:
+            series = scrapers.BatotoSeries(url)
+            series.follow()
+
+        chapter = db.session.query(db.Chapter).first()
+        chapter.added_on = datetime.datetime(2013, 12, 11, hour=10, minute=9)
+        db.session.commit()
+        time.sleep(2)
+
+        result = self.invoke('latest', 'cat-gravity')
+        assert result.exit_code == 0
+        assert MESSAGE == result.output
+
     def test_latest_never(self):
         URL = 'http://bato.to/comic/_/comics/cat-gravity-r11269'
         MESSAGE = 'cat-gravity   never'


### PR DESCRIPTION
The `alias` parameter used to be unused entirely. Implementing this functionality was trivial though, and now the command works as intended.

A test for the code path was added as well, which checks that the resulting output really is just one line, and the correct one at that.