### PR TITLE
Fix scraping HTTPS URLs on yuri-ism.net

### DIFF
--- a/cum/scrapers/yuriism.py
+++ b/cum/scrapers/yuriism.py
@@ -3,8 +3,8 @@ import re
 
 
 class YuriismSeries(FoOlSlideSeries):
-    BASE_URL = 'http://www.yuri-ism.net/slide/'
-    url_re = re.compile(r'http://www\.yuri-ism\.net/slide/series/')
+    BASE_URL = 'https://www.yuri-ism.net/slide/'
+    url_re = re.compile(r'https?://www\.yuri-ism\.net/slide/series/')
 
     def get_chapters(self):
         return super().get_chapters(YuriismChapter)
@@ -12,7 +12,7 @@ class YuriismSeries(FoOlSlideSeries):
 
 class YuriismChapter(FoOlSlideChapter):
     BASE_URL = YuriismSeries.BASE_URL
-    url_re = re.compile(r'http://www\.yuri-ism\.net/slide/read/')
+    url_re = re.compile(r'https?://www\.yuri-ism\.net/slide/read/')
 
     def from_url(url):
         return FoOlSlideChapter.from_url(url, YuriismSeries)


### PR DESCRIPTION
Also, to be on the "safe side", always use the HTTPS BASE_URL, since detection of whether the requested URLs use HTTPS or not is not trivial in all cases.