### PR TITLE
Fix scraping HTTPS URLs on yuri-ism.net

### DIFF
--- a/cum/scrapers/foolslide.py
+++ b/cum/scrapers/foolslide.py
@@ -11,10 +11,11 @@ import requests
 
 
 class FoOlSlideSeries(BaseSeries, metaclass=ABCMeta):
-    def __init__(self, url, directory=None, stub=None):
+    def __init__(self, url, directory=None, stub=None, use_https=False):
         self.url = url
         self.directory = directory
         self.stub = stub
+        self.use_https = use_https
         self._page = 1
         self.get_comic_details()
         self.chapters = self.get_chapters()
@@ -97,6 +98,10 @@ class FoOlSlideChapter(BaseChapter, metaclass=ABCMeta):
     def __init__(self, *args, **kwargs):
         super().__init__(*args, **kwargs)
         self.api_id = kwargs.get('api_id')
+        if self.url.split("://")[0] == "https":
+            self.use_https = True
+        else:
+            self.use_https = False
 
     @property
     def api_hook_details(self):
@@ -121,7 +126,8 @@ class FoOlSlideChapter(BaseChapter, metaclass=ABCMeta):
     def from_url(url, series_object):
         url = re.search(FoOlSlideChapter.no_pages_re, url).group(1)
         url_name = re.search(FoOlSlideChapter.url_name_re, url).group(1)
-        series = series_object(None, stub=url_name)
+        series = series_object(None, stub=url_name,
+                               use_https=(url.split("://")[0] == "https"))
         for chapter in series.chapters:
-            if chapter.url == url:
+            if chapter.url.split("://")[1] == url.split("://")[1]:
                 return chapter

--- a/cum/scrapers/yuriism.py
+++ b/cum/scrapers/yuriism.py
@@ -3,8 +3,14 @@ import re
 
 
 class YuriismSeries(FoOlSlideSeries):
-    BASE_URL = 'http://www.yuri-ism.net/slide/'
-    url_re = re.compile(r'http://www\.yuri-ism\.net/slide/series/')
+    url_re = re.compile(r'https?://www\.yuri-ism\.net/slide/series/')
+
+    @property
+    def BASE_URL(self):
+        if self.use_https:
+            return 'https://www.yuri-ism.net/slide/'
+        else:
+            return 'http://www.yuri-ism.net/slide/'
 
     def get_chapters(self):
         return super().get_chapters(YuriismChapter)
@@ -12,7 +18,7 @@ class YuriismSeries(FoOlSlideSeries):
 
 class YuriismChapter(FoOlSlideChapter):
     BASE_URL = YuriismSeries.BASE_URL
-    url_re = re.compile(r'http://www\.yuri-ism\.net/slide/read/')
+    url_re = re.compile(r'https?://www\.yuri-ism\.net/slide/read/')
 
     def from_url(url):
         return FoOlSlideChapter.from_url(url, YuriismSeries)

--- a/tests/test_scraper_yuriism.py
+++ b/tests/test_scraper_yuriism.py
@@ -32,6 +32,28 @@ class TestDokiReader(CumTest):
             files = chapter_zip.infolist()
             self.assertEqual(len(files), 18)
 
+    def test_chapter_kancolle_2_https(self):
+        URL = 'https://www.yuri-ism.net/slide/read/kancolle/en/6/2/page/1'
+        URL_SHORT = 'https://www.yuri-ism.net/slide/read/kancolle/en/6/2/'
+        ALIAS = 'kancolle'
+        NAME = 'Kancolle'
+        chapter = yuriism.YuriismChapter.from_url(URL)
+        self.assertEqual(chapter.alias, ALIAS)
+        self.assertTrue(chapter.available())
+        self.assertEqual(chapter.chapter, '2')
+        self.assertIs(chapter.directory, None)
+        self.assertEqual(chapter.groups, ['Yuri-ism'])
+        self.assertEqual(chapter.name, NAME)
+        self.assertEqual(chapter.url, URL_SHORT)
+        path = os.path.join(self.directory.name, NAME,
+                            'Kancolle - c002 [Yuri-ism].zip')
+        self.assertEqual(chapter.filename, path)
+        chapter.download()
+        self.assertTrue(os.path.isfile(path))
+        with zipfile.ZipFile(path) as chapter_zip:
+            files = chapter_zip.infolist()
+            self.assertEqual(len(files), 18)
+
     def test_series_invalid(self):
         URL = 'http://www.yuri-ism.net/slide/series/not_a_manga/'
         with self.assertRaises(exceptions.ScrapingError):
@@ -43,6 +65,28 @@ class TestDokiReader(CumTest):
         GROUPS = ['Yuri-ism']
         NAME = 'Joshiraku'
         URL = 'http://www.yuri-ism.net/slide/series/joshiraku/'
+        series = yuriism.YuriismSeries(URL)
+        self.assertEqual(series.name, NAME)
+        self.assertEqual(series.alias, ALIAS)
+        self.assertEqual(series.url, URL)
+        self.assertIs(series.directory, None)
+        self.assertEqual(len(series.chapters), len(CHAPTERS))
+        for chapter in series.chapters:
+            self.assertEqual(chapter.name, NAME)
+            self.assertEqual(chapter.alias, ALIAS)
+            self.assertIn(chapter.chapter, CHAPTERS)
+            CHAPTERS.remove(chapter.chapter)
+            for group in chapter.groups:
+                self.assertIn(group, GROUPS)
+            self.assertIs(chapter.directory, None)
+        self.assertEqual(len(CHAPTERS), 0)
+
+    def test_series_joshiraku_https(self):
+        ALIAS = 'joshiraku'
+        CHAPTERS = ['166']
+        GROUPS = ['Yuri-ism']
+        NAME = 'Joshiraku'
+        URL = 'https://www.yuri-ism.net/slide/series/joshiraku/'
         series = yuriism.YuriismSeries(URL)
         self.assertEqual(series.name, NAME)
         self.assertEqual(series.alias, ALIAS)


### PR DESCRIPTION
The BASE_URL will check whether HTTPS was requested, so that the used URLs will always be what a user expects.

Tests were added for HTTPS URLs.