### PR TITLE
Fix Specials for some DynastyScans series

### DIFF
--- a/cum/scrapers/dynastyscans.py
+++ b/cum/scrapers/dynastyscans.py
@@ -7,8 +7,9 @@ import concurrent.futures
 import re
 import requests
 
-name_re = re.compile(r'Chapter ([0-9\.]+)(?:$|\: )(.*)')
-fallback_re = re.compile(r'(.*?)(?:$|\: )(.*)')
+name_re = re.compile(r'(?P<type>Chapter|Special) (?P<num>[0-9\.]+)(?:$|\: )'
+                     r'(?P<title>.*)')
+fallback_re = re.compile(r'(?P<num>.*?)(?:$|\: )(?P<title>.*)')
 
 
 class DynastyScansSeries(BaseSeries):
@@ -28,8 +29,12 @@ class DynastyScansSeries(BaseSeries):
             name_parts = re.search(name_re, link.string)
             if not name_parts:
                 name_parts = re.search(fallback_re, link.string)
-            chapter = name_parts.group(1)
-            title = name_parts.group(2)
+                chapter = name_parts.group('num')
+            elif name_parts.group('type') == 'Special':
+                chapter = 'Special ' + name_parts.group('num')
+            else:
+                chapter = name_parts.group('num')
+            title = name_parts.group('title')
             url = urljoin(self.url, link.get('href'))
             c = DynastyScansChapter(name=self.name, alias=self.alias,
                                     chapter=chapter, url=url, title=title)

--- a/tests/test_scraper_dynastyscans.py
+++ b/tests/test_scraper_dynastyscans.py
@@ -85,6 +85,21 @@ class TestDynastyScans(CumTest):
             files = chapter_zip.infolist()
             self.assertEqual(len(files), 8)
 
+    def test_series_lily_love(self):
+        ALIAS = 'lily-love'
+        CHAPTERS = ['1', '2', '3', '4', '5', '6', '7', '8', '9', '10', '11',
+                    '12', '13', '14', '15', '16', '17', 'Special 1',
+                    'Special 2', '18', '19', '20']
+        URL = 'http://dynasty-scans.com/series/lily_love'
+        series = dynastyscans.DynastyScansSeries(URL)
+        scraped_chapters = [x.chapter for x in series.chapters]
+        for c in CHAPTERS:
+            self.assertEqual(scraped_chapters.count(c), 1)
+        filenames = []
+        for sc in series.chapters:
+            self.assertNotIn(sc.filename, filenames)
+            filenames.append(sc.filename)
+
     def test_series_stretch(self):
         ALIAS = 'stretch'
         CHAPTERS = ['0', '1', '2', '3', '4', '5', '6', '7', '8', '9', '10',


### PR DESCRIPTION
Some series have their specials labelled in a certain way which previously made cum overwrite regular chapters with the specials.

This changes the regex to have named groups, and a group to catch whether something is a chapter or a special is introduced.

A unit test which checks one series that previously exhibited this issue is added, in which the chapter names and the filenames are checked to be unique.

Somewhat relates to #35, but does not fix the original batoto-specific issue.