### PR TITLE
dynastyscans: Scrape using JSON endpoints

### DIFF
--- a/cum/scrapers/dynastyscans.py
+++ b/cum/scrapers/dynastyscans.py
@@ -96,8 +96,8 @@ class DynastyScansChapter(BaseChapter):
         if author_link:
             series = DynastyScansSeries(author_link)
             for chapter in series.chapters:
-                    if chapter.url == url:
-                        return chapter
+                if chapter.url == url:
+                    return chapter
         # if the chapter is a one-shot
         name = j['title']
         return DynastyScansChapter(name=name, chapter='0', url=url)

--- a/cum/scrapers/dynastyscans.py
+++ b/cum/scrapers/dynastyscans.py
@@ -81,12 +81,21 @@ class DynastyScansChapter(BaseChapter):
             url = url[:-1]
         r = requests.get(url + '.json')
         j = json.loads(r.text)
+        author_link = None
         for t in j['tags']:
             if t['type'] == 'Series':
                 series_url = urljoin('http://dynasty-scans.com/series/',
                                      t['permalink'])
                 series = DynastyScansSeries(series_url)
                 for chapter in series.chapters:
+                    if chapter.url == url:
+                        return chapter
+            elif t['type'] == 'Author':
+                author_link = urljoin('http://dynasty-scans.com/authors/',
+                                      t['permalink'])
+        if author_link:
+            series = DynastyScansSeries(author_link)
+            for chapter in series.chapters:
                     if chapter.url == url:
                         return chapter
         # if the chapter is a one-shot


### PR DESCRIPTION
dynasty-scans.com has largely undocumented JSON endpoints, which this change makes use of. Instead of parsing through fragile HTML, we can now enumerate the data we need from the JSON endpoints.

This reduces the amount of requests we need to make, particularly for the get_groups method. It also reduces code complexity somewhat, as we now no longer need to iterate through the HTML DOM multiple times to get all the info we need.

For now, headings such as "Volume 1" are skipped. These could be used for volume specific shenanigans in the future if need be.