### PR TITLE
Add a configuration checker

### DIFF
--- a/cum/config.py
+++ b/cum/config.py
@@ -36,8 +36,16 @@ class BaseConfig(object):
         except FileNotFoundError:
             j = {}
         else:
-            j = json.load(f)
-            f.close()
+            try:
+                j = json.load(f)
+            except json.decoder.JSONDecodeError as e:
+                f.seek(0, 0)
+                raise exceptions.ConfigError(config=f.read(),
+                                             cursor=(e.lineno, e.colno),
+                                             message='Error reading config: {}'
+                                                     .format(e.msg))
+            finally:
+                f.close()
 
         self.batoto = BatotoConfig(self, j.get('batoto', {}))
         self.cbz = j.get('cbz', False)

--- a/cum/cum.py
+++ b/cum/cum.py
@@ -32,8 +32,13 @@ def edit_defaults():
                       message=version.version_string())
 def cli(cum_directory=None):
     global db, output, sanity, utility
-    config.initialize(directory=cum_directory)
-    from cum import db, output, sanity, utility
+    from cum import output
+    try:
+        config.initialize(directory=cum_directory)
+    except exceptions.ConfigError as e:
+        output.configuration_error(e)
+        exit(1)
+    from cum import db, sanity, utility
     db.initialize()
     edit_defaults()
 

--- a/cum/exceptions.py
+++ b/cum/exceptions.py
@@ -12,9 +12,21 @@ class CumException(Exception):
         return repr(self.message)
 
 
+class LoginError(CumException):
+    pass
+
+
 class ScrapingError(CumException):
     pass
 
 
-class LoginError(CumException):
-    pass
+class ConfigError(CumException):
+    """Exception that is thrown when cum encounters a malformed configuration
+    file. Accepts a string representing the raw text of the configuration file,
+    the cursor position as a (row, column) tuple and a message.
+    """
+
+    def __init__(self, config, cursor, message=''):
+        self.config = config
+        self.cursor = cursor
+        super().__init__(message)

--- a/cum/output.py
+++ b/cum/output.py
@@ -15,6 +15,25 @@ def configuration(dictionary):
             click.echo('{} = {}'.format(setting, value))
 
 
+def configuration_error(config_error):
+    """Prints up to 5 lines of the configuration file, with an arrow pointing
+    towards the position at which the configuration error was encountered,
+    and an error message describing it.
+    """
+
+    sc = config_error.config.splitlines()
+    max_num_len = len(str(config_error.cursor[0]))
+    start_line = max(config_error.cursor[0] - 5, 0)
+    for l in range(start_line, config_error.cursor[0]):
+        click.echo(
+            click.style(str(l).rjust(max_num_len) + ': ', fg='blue') + sc[l]
+        )
+    # column count - 1 as it starts with 0, + line num length, + separator
+    arrow = (config_error.cursor[1] - 1 + max_num_len + 2) * ' ' + '^'
+    click.secho(arrow, fg='red', bold=True)
+    error(config_error.message)
+
+
 def configuration_flatten(dictionary, parent_key=None):
     items = []
     for key, value in dictionary.items():

--- a/tests/broken_config.json
+++ b/tests/broken_config.json
@@ -1,0 +1,17 @@
+{
+  "batoto": {
+    "cookie": "invalid",
+    "member_id": "invalid",
+    "pass_hash": "invalid",
+    "password": "invalid",
+    "username": "invalid"
+  },
+  "cbz": true,
+  "compact_new": true,
+  "download_directory": "invalid",
+  "madokami": {
+    "password": "invalid",
+    "username": "invalid"
+    I am so broken
+  }
+}

--- a/tests/cumtest.py
+++ b/tests/cumtest.py
@@ -15,6 +15,15 @@ class CumTest(unittest.TestCase):
         self.madokami_password = os.environ.get('MADOKAMI_PASSWORD', None)
         self.madokami_username = os.environ.get('MADOKAMI_USERNAME', None)
 
+    def copy_broken_config(self):
+        """Copies a pre-defined broken configuration file into the current
+        directory.
+        """
+        test_directory = os.path.dirname(os.path.realpath(__file__))
+        broken_config_path = os.path.join(test_directory, 'broken_config.json')
+        target_config_path = os.path.join(self.directory.name, 'config.json')
+        copyfile(broken_config_path, target_config_path)
+
     def copy_broken_database(self):
         """Copies a pre-defined broken database into the current directory."""
         test_directory = os.path.dirname(os.path.realpath(__file__))

--- a/tests/test_cli_config.py
+++ b/tests/test_cli_config.py
@@ -1,8 +1,29 @@
 from cum import config
+from cum import exceptions
 import cumtest
 
 
 class TestCLIConfig(cumtest.CumCLITest):
+    def test_config_corrupt(self):
+        self.copy_broken_config()
+        with self.assertRaises(exceptions.ConfigError):
+            config.initialize(self.directory.name)
+
+    def test_config_corrupt_output(self):
+        MESSAGES = ['10:   "download_directory": "invalid",',
+                    '11:   "madokami": {',
+                    '12:     "password": "invalid",',
+                    '13:     "username": "invalid"',
+                    '14:     I am so broken',
+                    '        ^',
+                    '==> Error reading config: Expecting \',\' delimiter']
+
+        self.copy_broken_config()
+        result = self.invoke('config', 'initialise', self.directory.name)
+        self.assertEqual(result.exit_code, 1)
+        for message in MESSAGES:
+            self.assertIn(message, result.output)
+
     @cumtest.skipIfNoBatotoLogin
     @cumtest.skipIfNoMadokamiLogin
     def test_config_get(self):


### PR DESCRIPTION
Essentially, this adds some logic to catch parsing exceptions when reading malformed JSON files, and then presents them as user-friendly error messages.