### PR TITLE
Fix names longer than term width causing div zero err with 'follows'

### DIFF
--- a/cum/output.py
+++ b/cum/output.py
@@ -78,6 +78,8 @@ def list(items):
         width = click.get_terminal_size()[0]
         longest = len(max(items, key=len))
         columns = int(width // (longest + 0.5))
+        if columns < 1:
+            columns = 1
         rows = ceil(len(items) / columns)
 
         for row in range(rows):


### PR DESCRIPTION
I have a follow on batoto for a manga with a ridiculously long 95 character name (uchi-no-musume-no-tame-naraba-ore-wa-moshikashitara-maou-mo-taoseru-kamo-shirenai), which causes a division by zero error on attempt to 'cum follows'.