### PR TITLE
Trim all dots/whitespace from end of dirname for Windows

### DIFF
--- a/cum/scrapers/base.py
+++ b/cum/scrapers/base.py
@@ -105,6 +105,9 @@ class BaseChapter(metaclass=ABCMeta):
         path = ''.join([char for char in path if char.isalpha() or
                         char.isdigit() or char in KEEP_CHARACTERS]).rstrip()
         path = sub(' +', ' ', path)
+        if sys.platform in ['cygwin', 'win32']:
+            no_end_dots_re = r'[\.\s]*$'
+            path = sub( no_end_dots_re, '', path )
         if path_start:
             path = ''.join([path_start, path])
         return path


### PR DESCRIPTION
Windows doesn't allow . + whitespace at the end of directory names - but it just drops them invisibly instead of throwing an error. So for 'The Hero Suddenly Proposed to Me, but . . . ', the directory gets created as 'The Hero Suddenly Proposed to Me, but' and then create_zip() throws an exception because the directory doesn't exist.  This strips them off the end first.