### PR TITLE
Fix mangadex scrapper after site moved to mangadex.org

### DIFF
--- a/cum/db.py
+++ b/cum/db.py
@@ -227,7 +227,7 @@ class Chapter(Base):
             'directory': self.series.directory,
             'api_id': self.api_id
         }
-        if parse.netloc == 'mangadex.com':
+        if parse.netloc in ('mangadex.com', 'mangadex.org'):
             from cum.scrapers.mangadex import MangadexChapter
             return MangadexChapter(**kwargs)
         if parse.netloc == 'bato.to':

--- a/cum/scrapers/mangadex.py
+++ b/cum/scrapers/mangadex.py
@@ -10,7 +10,7 @@ import requests
 
 
 class MangadexSeries(BaseSeries):
-    """Scraper for mangadex.com.
+    """Scraper for mangadex.org.
 
     Some examples of chapter info used by Mangadex (matched with `name_re`):
         Vol. 2 Ch. 18 - Strange-flavored Ramen
@@ -19,7 +19,7 @@ class MangadexSeries(BaseSeries):
         Vol. 2 Ch. 8 v2 - Read Online
         Oneshot
     """
-    url_re = re.compile(r'(?:https?://mangadex\.com)?/manga/([0-9]+)')
+    url_re = re.compile(r'(?:https?://mangadex\.(?:org|com))?/manga/([0-9]+)')
     name_re = re.compile(r'Ch\. ?([A-Za-z0-9\.\-]*)(?: v[0-9]+)?(?: - (.*))')
     language_re = re.compile(r'/images/flags/')
     group_re = re.compile(r'/group/([0-9]+)')
@@ -40,7 +40,7 @@ class MangadexSeries(BaseSeries):
         manga_name = self.name
         for a in links:
             url = a.get('href')
-            url_match = re.search(MangadexChapter.url_re, url)
+            url_match = re.search(MangadexChapter.url_re, url) if url else None
             if not url_match:
                 continue
             name = a.string
@@ -57,7 +57,7 @@ class MangadexSeries(BaseSeries):
             groups = [a.parent.parent.find('a', href=self.group_re).string]
             c = MangadexChapter(name=manga_name, alias=self.alias,
                                 chapter=chapter,
-                                url=urljoin('https://mangadex.com', url),
+                                url=urljoin('https://mangadex.org', url),
                                 groups=groups, title=title)
             chapters = [c] + chapters
         return chapters
@@ -70,7 +70,8 @@ class MangadexSeries(BaseSeries):
 
 
 class MangadexChapter(BaseChapter):
-    url_re = re.compile(r'(?:https?://mangadex\.com)?/chapter/([0-9]+)')
+    url_re = re.compile(
+        r'(?:https?://mangadex\.(?:org|com))?/chapter/([0-9]+)')
     # There is an inlined js with a bunch of useful variables
     hash_re = re.compile(r'var dataurl ?= ?\'([A-Za-z0-9]{32})\'')
     # Example: (mind that the trailing comma is invalid json)
@@ -80,7 +81,7 @@ class MangadexChapter(BaseChapter):
     # Just extract the single page name like: x1.jpg
     single_page_re = re.compile(r'\s?\'([^\']+)\',?')
     # This can be a mirror server or data path. Example:
-    # var server = 'https://s2.mangadex.com/'
+    # var server = 'https://s2.mangadex.org/'
     # var server = '/data/'
     server_re = re.compile(r'var server ?= ?\'([^\']+)\'')
     uses_pages = True
@@ -112,7 +113,7 @@ class MangadexChapter(BaseChapter):
         pages = re.findall(self.single_page_re, pages_var.group(1))
         files = [None] * len(pages)
         mirror = re.search(self.server_re, r.text).group(1)
-        server = urljoin('https://mangadex.com', mirror)
+        server = urljoin('https://mangadex.org', mirror)
         futures = []
         last_image = None
         with self.progress_bar(pages) as bar:
@@ -141,7 +142,7 @@ class MangadexChapter(BaseChapter):
             series_url = soup.find('a', href=MangadexSeries.url_re)['href']
         except TypeError:
             raise exceptions.ScrapingError('Chapter has no parent series link')
-        series = MangadexSeries(urljoin('https://mangadex.com', series_url))
+        series = MangadexSeries(urljoin('https://mangadex.org', series_url))
         for chapter in series.chapters:
             parsed_chapter_url = ''.join(urlparse(chapter.url)[1:])
             parsed_url = ''.join(urlparse(url)[1:])

--- a/tests/test_scraper_mangadex.py
+++ b/tests/test_scraper_mangadex.py
@@ -18,7 +18,7 @@ def language_filter(a):
         return None
 
 class TestMangadex(cumtest.CumTest):
-    MANGADEX_URL = 'https://mangadex.com/'
+    MANGADEX_URL = 'https://mangadex.org/'
 
     def setUp(self):
         super().setUp()
@@ -66,7 +66,7 @@ class TestMangadex(cumtest.CumTest):
                 chapter.get(use_db=False)
 
     def test_chapter_filename_decimal(self):
-        URL = 'https://mangadex.com/chapter/24779'
+        URL = 'https://mangadex.org/chapter/24779'
         chapter = mangadex.MangadexChapter.from_url(URL)
         path = os.path.join(
             self.directory.name, 'Citrus Saburouta',
@@ -76,7 +76,7 @@ class TestMangadex(cumtest.CumTest):
         self.assertEqual(chapter.filename, path)
 
     def test_chapter_filename_version2(self):
-        URL = 'https://mangadex.com/chapter/12361'
+        URL = 'https://mangadex.org/chapter/12361'
         chapter = mangadex.MangadexChapter.from_url(URL)
         path = os.path.join(
             self.directory.name, 'Urara Meirochou',
@@ -86,7 +86,7 @@ class TestMangadex(cumtest.CumTest):
         self.assertEqual(chapter.filename, path)
 
     def test_chapter_information_ramen_daisuki_koizumi_san(self):
-        URL = 'https://mangadex.com/chapter/26441'
+        URL = 'https://mangadex.org/chapter/26441'
         chapter = mangadex.MangadexChapter.from_url(URL)
         self.assertEqual(chapter.alias, 'ramen-daisuki-koizumi-san')
         self.assertTrue(chapter.available())
@@ -105,7 +105,7 @@ class TestMangadex(cumtest.CumTest):
             self.assertEqual(len(files), 8)
 
     def test_chapter_information_hidamari_sketch(self):
-        URL = 'https://mangadex.com/chapter/9833'
+        URL = 'https://mangadex.org/chapter/9833'
         chapter = mangadex.MangadexChapter.from_url(URL)
         self.assertEqual(chapter.alias, 'hidamari-sketch')
         self.assertEqual(chapter.chapter, '001-013')
@@ -124,7 +124,7 @@ class TestMangadex(cumtest.CumTest):
             self.assertEqual(len(files), 150)
 
     def test_chapter_information_tomochan(self):
-        URL = 'https://mangadex.com/chapter/28082'
+        URL = 'https://mangadex.org/chapter/28082'
         config.get().cbz = True
         chapter = mangadex.MangadexChapter.from_url(URL)
         self.assertEqual(chapter.alias, 'tomo-chan-wa-onna-no-ko')
@@ -144,7 +144,7 @@ class TestMangadex(cumtest.CumTest):
             self.assertEqual(len(files), 1)
 
     def test_chapter_unavailable(self):
-        URL = ''.join(['https://mangadex.com/chapter/',
+        URL = ''.join(['https://mangadex.org/chapter/',
                        '9999999999999999999999999999999999999999999999',
                        '99999999999999999999999'])
         chapter = mangadex.MangadexChapter(url=URL)
@@ -163,7 +163,7 @@ class TestMangadex(cumtest.CumTest):
                              '57.5', '58', '59', '60', '60.5'],
                 'groups': ['promfret', 'Amano Centric Scans'],
                 'name': 'Aria',
-                'url': 'https://mangadex.com/manga/2007'}
+                'url': 'https://mangadex.org/manga/2007'}
         self.series_information_tester(data)
 
     def test_series_prunus_girl(self):
@@ -176,7 +176,7 @@ class TestMangadex(cumtest.CumTest):
                              '38', '39', '40', '41', '42', '43'],
                 'groups': ['Unknown', 'WOWScans!', 'Maigo'],
                 'name': 'Prunus Girl',
-                'url': 'https://mangadex.com/manga/18'}
+                'url': 'https://mangadex.org/manga/18'}
         self.series_information_tester(data)
 
 if __name__ == '__main__':


### PR DESCRIPTION
Hello,

I was not able to use mangadex scrapper as it failed to recognize mangadex.org urls. mangadex.com automatically redirects to mangadex.org, so I believe that is their new "default" address.

This PR fixes the problem.