### PR TITLE
Use the new mangadex json api to fetch chapters and series.

### DIFF
--- a/cum/scrapers/mangadex.py
+++ b/cum/scrapers/mangadex.py
@@ -13,7 +13,7 @@ import json
 
 
 class MangadexSeries(BaseSeries):
-    url_re = re.compile(r'(?:https?://mangadex\.(?:org|com))?/(?:manga|title)/([0-9]+)')
+    url_re = re.compile(r'(?:https?://mangadex\.org)?/(?:manga|title)/([0-9]+)')
     # TODO remove when there are properly spaced api calls
     spam_failures = 0
 
@@ -74,7 +74,7 @@ class MangadexSeries(BaseSeries):
 class MangadexChapter(BaseChapter):
     # match /chapter/12345 and avoid urls like /chapter/1235/comments
     url_re = re.compile(
-        r'(?:https?://mangadex\.(?:org|com))?/chapter/([0-9]+)'
+        r'(?:https?://mangadex\.org)?/chapter/([0-9]+)'
         r'(?:/[^a-zA-Z0-9]|/?$)'
     )
     uses_pages = True

--- a/cum/scrapers/mangadex.py
+++ b/cum/scrapers/mangadex.py
@@ -13,7 +13,7 @@ import json
 
 
 class MangadexSeries(BaseSeries):
-    url_re = re.compile(r'(?:https?://mangadex\.(?:org|com))?/manga/([0-9]+)')
+    url_re = re.compile(r'(?:https?://mangadex\.(?:org|com))?/(?:manga|title)/([0-9]+)')
     # TODO remove when there are properly spaced api calls
     spam_failures = 0
 

--- a/cum/scrapers/mangadex.py
+++ b/cum/scrapers/mangadex.py
@@ -7,87 +7,46 @@ from urllib.parse import urljoin, urlparse
 import concurrent.futures
 import re
 import requests
+import json
 
 
 class MangadexSeries(BaseSeries):
-    """Scraper for mangadex.org.
-
-    Some examples of chapter info used by Mangadex (matched with `name_re`):
-        Vol. 2 Ch. 18 - Strange-flavored Ramen
-        Ch. 7 - Read Online
-        Vol. 01 Ch. 001-013 - Read Online
-        Vol. 2 Ch. 8 v2 - Read Online
-        Oneshot
-    """
     url_re = re.compile(r'(?:https?://mangadex\.(?:org|com))?/manga/([0-9]+)')
-    name_re = re.compile(r'Ch\. ?([A-Za-z0-9\.\-]*)(?: v[0-9]+)?(?: - (.*))')
-    language_re = re.compile(r'/images/flags/')
-    group_re = re.compile(r'/group/([0-9]+)')
 
     def __init__(self, url, **kwargs):
         super().__init__(url, **kwargs)
         self._get_page(self.url)
         self.chapters = self.get_chapters()
-        # fetch paginated chapters
-        while True:
-            next_url = self._get_next_url()
-            if not next_url:
-                break
-            self._get_page(next_url)
-            self.chapters = self.get_chapters() + self.chapters
 
     def _get_page(self, url):
-        r = requests.get(url)
-        self.soup = BeautifulSoup(r.text, config.get().html_parser)
-
-    def _get_next_url(self):
-        pagination = self.soup.find('ul', class_='pagination')
-        active_item = (pagination.find('li', class_='active')
-                       if pagination else None)
-        next_item = (active_item.find_next_sibling('li', class_='paging')
-                     if active_item else None)
-        next_link = next_item.find('a') if next_item else None
-        next_url = next_link.get('href') if next_link else None
-        return urljoin('https://mangadex.com', next_url) if next_url else None
+        manga_id = re.search(self.url_re, url)
+        r = requests.get('https://mangadex.org/api/manga/' + manga_id.group(1))
+        self.json = json.loads(r.text)
 
     def get_chapters(self):
-        links = self.soup.find_all('a')
-        chapters = []
-
+        result_chapters = []
         manga_name = self.name
-        for a in links:
-            url = a.get('href')
-            url_match = re.search(MangadexChapter.url_re, url) if url else None
-            if not url_match:
-                continue
-            name = a.string
-            if not name:
-                print("no name for {}".format(url))
-                continue
-            name = name.strip()
-            name_parts = re.search(self.name_re, name)
-            chapter = name_parts.group(1) if name_parts else name
-            title = name_parts.group(2) if name_parts else None
-            title = None if title == 'Read Online' else title
-            language = a.parent.parent.find('img', src=self.language_re)\
-                                      .get('title')
+        chapters = self.json['chapter']
+        for c in chapters:
+            url = 'https://mangadex.org/chapter/' + c
+            chapter = chapters[c]['chapter']
+            title = chapters[c]['title'] if chapters[c]['title'] else None
+            language = chapters[c]['lang_code']
             # TODO: Add an option to filter by language.
-            if language != 'English':
+            if language != 'gb':
                 continue
-            groups = [a.parent.parent.find('a', href=self.group_re).string]
-            c = MangadexChapter(name=manga_name, alias=self.alias,
-                                chapter=chapter,
-                                url=urljoin('https://mangadex.org', url),
-                                groups=groups, title=title)
-            chapters = [c] + chapters
-        return chapters
+            groups = [chapters[c]['group_name']]
+            
+            result = MangadexChapter(name=manga_name, alias=self.alias,
+                                     chapter=chapter,
+                                     url=url,
+                                     groups=groups, title=title)
+            result_chapters = [result] + result_chapters
+        return result_chapters
 
     @property
     def name(self):
-        title_re = re.compile(r'^(.+) \(Manga\) - MangaDex')
-        title = self.soup.find('title').string.strip()
-        return re.search(title_re, title).group(1)
-
+        return self.json['manga']['title']
 
 class MangadexChapter(BaseChapter):
     # match /chapter/12345 and avoid urls like /chapter/1235/comments
@@ -95,23 +54,13 @@ class MangadexChapter(BaseChapter):
         r'(?:https?://mangadex\.(?:org|com))?/chapter/([0-9]+)'
         r'(?:/[^a-zA-Z0-9]|/?$)'
     )
-    # There is an inlined js with a bunch of useful variables
-    hash_re = re.compile(r'var dataurl ?= ?\'([A-Za-z0-9]{32})\'')
-    # Example: (mind that the trailing comma is invalid json)
-    # var page_array = [
-    # 'x1.jpg','x2.jpg','x3.jpg','x4.jpg','x5.jpg','x6.png',];
-    pages_re = re.compile(r'var page_array ?= ?\[([^\]]+)\]', re.DOTALL)
-    # Just extract the single page name like: x1.jpg
-    single_page_re = re.compile(r'\s?\'([^\']+)\',?')
-    # This can be a mirror server or data path. Example:
-    # var server = 'https://s2.mangadex.org/'
-    # var server = '/data/'
-    server_re = re.compile(r'var server ?= ?\'([^\']+)\'')
     uses_pages = True
 
     @staticmethod
     def _reader_get(url, page_index):
-        return requests.get(url)
+        chapter_id = re.search(MangadexChapter.url_re, url)
+        api_url = "https://mangadex.org/api/chapter/" + chapter_id.group(1)
+        return requests.get(api_url)
 
     def available(self):
         self.r = self.reader_get(1)
@@ -125,17 +74,19 @@ class MangadexChapter(BaseChapter):
         else:
             return True
 
-    def download(self):
+    def download(self): 
         if getattr(self, 'r', None):
             r = self.r
         else:
             r = self.reader_get(1)
-        soup = BeautifulSoup(r.text, config.get().html_parser)
-        chapter_hash = re.search(self.hash_re, r.text).group(1)
-        pages_var = re.search(self.pages_re, r.text)
-        pages = re.findall(self.single_page_re, pages_var.group(1))
+
+        chapter_hash = self.json['hash']
+        pages = self.json['page_array']
         files = [None] * len(pages)
-        mirror = re.search(self.server_re, r.text).group(1)
+        # This can be a mirror server or data path. Example:
+        # var server = 'https://s2.mangadex.org/'
+        # var server = '/data/'
+        mirror = self.json['server']
         server = urljoin('https://mangadex.org', mirror)
         futures = []
         last_image = None
@@ -160,12 +111,9 @@ class MangadexChapter(BaseChapter):
 
     def from_url(url):
         r = MangadexChapter._reader_get(url, 1)
-        soup = BeautifulSoup(r.text, config.get().html_parser)
-        try:
-            series_url = soup.find('a', href=MangadexSeries.url_re)['href']
-        except TypeError:
-            raise exceptions.ScrapingError('Chapter has no parent series link')
-        series = MangadexSeries(urljoin('https://mangadex.org', series_url))
+        data = json.loads(r.text)
+        manga_id = data['manga_id']
+        series = MangadexSeries('https://mangadex.org/manga/' + str(manga_id))
         for chapter in series.chapters:
             parsed_chapter_url = ''.join(urlparse(chapter.url)[1:])
             parsed_url = ''.join(urlparse(url)[1:])
@@ -173,4 +121,6 @@ class MangadexChapter(BaseChapter):
                 return chapter
 
     def reader_get(self, page_index):
-        return self._reader_get(self.url, page_index)
+        r = self._reader_get(self.url, page_index)
+        self.json = json.loads(r.text)
+        return r

--- a/cum/scrapers/mangadex.py
+++ b/cum/scrapers/mangadex.py
@@ -26,7 +26,7 @@ class MangadexSeries(BaseSeries):
     def get_chapters(self):
         result_chapters = []
         manga_name = self.name
-        chapters = self.json['chapter']
+        chapters = self.json['chapter'] if self.json.get('chapter') else []
         for c in chapters:
             url = 'https://mangadex.org/chapter/' + c
             chapter = chapters[c]['chapter']

--- a/cum/scrapers/mangadex.py
+++ b/cum/scrapers/mangadex.py
@@ -36,7 +36,7 @@ class MangadexSeries(BaseSeries):
             # sleep 10-17 seconds to wait out the spam protection
             # and make it less likely for all threads to hit at the same time
             sleep(randrange(10000, 17000) / 1000.0)
-            self.spam_failures = self.spam_failures+1
+            self.spam_failures = self.spam_failures + 1
             return self._get_page(url)
         elif self.spam_failures >= 3:
             print("Error: Mangadex server probably contacted too often\n")
@@ -71,6 +71,7 @@ class MangadexSeries(BaseSeries):
     def name(self):
         return self.json['manga']['title']
 
+
 class MangadexChapter(BaseChapter):
     # match /chapter/12345 and avoid urls like /chapter/1235/comments
     url_re = re.compile(
@@ -97,7 +98,7 @@ class MangadexChapter(BaseChapter):
         else:
             return True
 
-    def download(self): 
+    def download(self):
         if getattr(self, 'r', None):
             r = self.r
         else:

--- a/tests/test_scraper_mangadex.py
+++ b/tests/test_scraper_mangadex.py
@@ -180,5 +180,13 @@ class TestMangadex(cumtest.CumTest):
                 'url': 'https://mangadex.org/manga/18'}
         self.series_information_tester(data)
 
+    def test_series_no_chapters(self):
+        data = {'alias': 'yorumori-no-kuni-no-sora-ni',
+                'chapters': [],
+                'groups': [],
+                'name': 'Yorumori no Kuni no Sora ni',
+                'url': 'https://mangadex.org/manga/13004'}
+        self.series_information_tester(data)
+
 if __name__ == '__main__':
     unittest.main()

--- a/tests/test_scraper_mangadex.py
+++ b/tests/test_scraper_mangadex.py
@@ -11,7 +11,7 @@ import zipfile
 
 def language_filter(a):
     try:
-        regex = mangadex.MangadexSeries.language_re
+        regex = re.compile(r'/images/flags/')
         return a.find_parent('tr').find('img', src=regex)['title'] == 'English'
     # ignore chapter links that do not state a language
     except TypeError:
@@ -30,7 +30,7 @@ class TestMangadex(cumtest.CumTest):
 
 
     def get_five_latest_releases(self):
-        r = requests.get(self.MANGADEX_URL)
+        r = requests.get(self.MANGADEX_URL + 'updates')
         soup = BeautifulSoup(r.text, config.get().html_parser)
         chapters = soup.find_all('a', href=mangadex.MangadexChapter.url_re)
         chapters = [a for a in chapters if language_filter(a)]
@@ -69,20 +69,21 @@ class TestMangadex(cumtest.CumTest):
         URL = 'https://mangadex.org/chapter/24779'
         chapter = mangadex.MangadexChapter.from_url(URL)
         path = os.path.join(
-            self.directory.name, 'Citrus Saburouta',
-            'Citrus Saburouta - c020 x9 [Chaosteam].zip'
+            self.directory.name, 'Citrus',
+            'Citrus - c020 x9 [Chaosteam].zip'
         )
         self.assertEqual(chapter.chapter, '20.9')
         self.assertEqual(chapter.filename, path)
 
     def test_chapter_filename_version2(self):
+        # 1v2 style version numbers seem to be omitted on the current site
         URL = 'https://mangadex.org/chapter/12361'
         chapter = mangadex.MangadexChapter.from_url(URL)
         path = os.path.join(
             self.directory.name, 'Urara Meirochou',
             'Urara Meirochou - c001 [Kyakka].zip'
         )
-        self.assertEqual(chapter.chapter, '1v2')
+        self.assertEqual(chapter.chapter, '1')
         self.assertEqual(chapter.filename, path)
 
     def test_chapter_information_ramen_daisuki_koizumi_san(self):
@@ -174,7 +175,7 @@ class TestMangadex(cumtest.CumTest):
                              '23', '24', '25', '26', '27', '28', '29', '30',
                              '31', '32', '32.5', '33', '34', '35', '36', '37',
                              '38', '39', '40', '41', '42', '43'],
-                'groups': ['Unknown', 'WOWScans!', 'Maigo'],
+                'groups': ['Unknown', 'WOW!Scans', 'Maigo'],
                 'name': 'Prunus Girl',
                 'url': 'https://mangadex.org/manga/18'}
         self.series_information_tester(data)

--- a/tests/test_scraper_mangadex.py
+++ b/tests/test_scraper_mangadex.py
@@ -109,20 +109,20 @@ class TestMangadex(cumtest.CumTest):
         URL = 'https://mangadex.org/chapter/9833'
         chapter = mangadex.MangadexChapter.from_url(URL)
         self.assertEqual(chapter.alias, 'hidamari-sketch')
-        self.assertEqual(chapter.chapter, '001-013')
+        self.assertEqual(chapter.chapter, '0')
         self.assertEqual(chapter.groups, ['Highlanders'])
         self.assertEqual(chapter.name, 'Hidamari Sketch')
         self.assertEqual(chapter.title, None)
         path = os.path.join(
             self.directory.name, 'Hidamari Sketch',
-            'Hidamari Sketch - c001-013 [Highlanders].zip'
+            'Hidamari Sketch - c000 [Highlanders].zip'
         )
         self.assertEqual(chapter.filename, path)
         chapter.download()
         self.assertTrue(os.path.isfile(path))
         with zipfile.ZipFile(path) as chapter_zip:
             files = chapter_zip.infolist()
-            self.assertEqual(len(files), 150)
+            self.assertEqual(len(files), 11)
 
     def test_chapter_information_tomochan(self):
         URL = 'https://mangadex.org/chapter/28082'


### PR DESCRIPTION
Adjusted the tests:
 - the latest releases list moved from the frontpage to /updates
 - Title of decimal point test changed
 - 1v2 version numbers seem to omit the v2 part everywhere on the site.

Tests pass on my machine:
````
python3 -m unittest discover -s ./tests/ -p 'test_scraper_mangadex.py'
love-rush 12
  [>>>>>>>>>>>>>>>>>>>>>>>>>>>>>>>>>>>>]  19/19  100%             
love-rush 11
  [>>>>>>>>>>>>>>>>>>>>>>>>>>>>>>>>>>>>]  19/19  100%             
love-rush 10
  [>>>>>>>>>>>>>>>>>>>>>>>>>>>>>>>>>>>>]  19/19  100%             
love-rush 9
  [>>>>>>>>>>>>>>>>>>>>>>>>>>>>>>>>>>>>]  19/19  100%             
hedgehog-harry 85
  [>>>>>>>>>>>>>>>>>>>>>>>>>>>>>>>>>>>>]  1/1  100%
...hidamari-sketch 001-013
  [>>>>>>>>>>>>>>>>>>>>>>>>>>>>>>>>>>>>]  150/150  100%             
.ramen-daisuki-koizumi-san 18
  [>>>>>>>>>>>>>>>>>>>>>>>>>>>>>>>>>>>>]  8/8  100%             
.tomo-chan-wa-onna-no-ko 1
  [>>>>>>>>>>>>>>>>>>>>>>>>>>>>>>>>>>>>]  1/1  100%
....
----------------------------------------------------------------------
Ran 9 tests in 39.328s
````

fixes https://github.com/Hamuko/cum/issues/63