### PR TITLE
Addresses changes to auth on Madokami

### DIFF
--- a/cum/version.py
+++ b/cum/version.py
@@ -1,4 +1,4 @@
-__version__ = '0.9.1'
+__version__ = 'git-04c7d86'
 __version_name__ = 'Morino Kirin-chan'
 
 


### PR DESCRIPTION
Fixes #71

Addresses changes to Madokami authentication, which is now validated by a cookie.
